### PR TITLE
Address still had Pennsylvania in it

### DIFF
--- a/consentagreements.json
+++ b/consentagreements.json
@@ -1675,7 +1675,7 @@
     "properties": {
       "marker-symbol": "marker",
       "marker-color": "#D4500F",
-      "address": "Lincoln University Pennsylvania 19352",
+      "address": "Lincoln University Missouri 19352",
       "URL": "http://studentaid.ed.gov/about/data-center/school/clery-act#lincoln",
       "Type of Report ": "Clery ",
       "Description": " ",


### PR DESCRIPTION
Minor update: changed Address field for Lincoln university in Missouri -- removed the 'Pennsylvania'
